### PR TITLE
Really fix # char handling

### DIFF
--- a/source/academy/mqtt.adoc
+++ b/source/academy/mqtt.adoc
@@ -40,9 +40,9 @@ The important thing is that the publisher and subscriber agree in advance on the
 Usually this will be given by the data model.
 
 Devices request to subscribe to messages in the same way - by sending the broker a special “subscribe” mesage with the name of the topic they want to subscribe to.
-Here, they may use wildcard symbols `\#` and `+`. The `+` symbol replaces one level, e.g. `building1/floor1/+/door` addresses the doors in all rooms on the first floor of building 1 - i.e. `building1/floor1/room101/door`, `building1/floor1/room102/door`, `building1/floor1/toilets/door` etc.
-The `\#` wildcard symbol replaces one or more levels and must always be last.
-Subscribing to topic `building1/floor1/#` means that messages will be received with all topics pertaining to the first floor of building 1.
+Here, they may use wildcard symbols `&num;` and `+`. The `+` symbol replaces one level, e.g. `building1/floor1/+/door` addresses the doors in all rooms on the first floor of building 1 - i.e. `building1/floor1/room101/door`, `building1/floor1/room102/door`, `building1/floor1/toilets/door` etc.
+The `&num;` wildcard symbol replaces one or more levels and must always be last.
+Subscribing to topic `building1/floor1/&num;` means that messages will be received with all topics pertaining to the first floor of building 1.
 
 There is one more note regarding naming convention:
 If the name of the topic starts with the `$` symbol, this is a special topic publishers cannot publish to.
@@ -152,7 +152,7 @@ The BigClown Hub enables communcation via MQTT.
 Defines topics and subtopics for data, and also defines the format of messages sent.
 
 The topic addresses a specific node.
-In the case of BigClown Bridge project it is the Bridge Module, and its topic is `nodes/bridge/0/#`.
+In the case of BigClown Bridge project it is the Bridge Module, and its topic is `nodes/bridge/0/&num;`.
 If you connect another Bridge Module, the topic will be `nodes/bridge/1` etc.
 
 Each sensor and actuator has its own subtopic, which gives the class of the device (thermometer, barometer etc.), and says where the device is connected, i.e. to which I^2^C bus and with what address.


### PR DESCRIPTION
Pull #70 didn't work as intended. Sometimes # chars in inline code segments are shown literal and sometimes they are interpreted, causing the escaping \ to be visible. This is probably a bug in AsciiDoctor. As a workaround we could just avoid it altogether by replacing # by &num; in all inline text as is done in /source/tutorial/mosquitto.adoc.

Note that &num; is a new HTML entity that won't be recognized by ancient web browsers such as IE9 (according to https://stackoverflow.com/questions/3025171/whats-the-html-character-entity-for-the-sign/27091747#27091747).