### PR TITLE
Place nodered.service in /etc

### DIFF
--- a/source/tutorial/node-red.adoc
+++ b/source/tutorial/node-red.adoc
@@ -57,7 +57,7 @@ Raspberry Pi has limited operating memory, that is why Node-RED must be run usin
 
 If you want Node-RED to run after every system start, you can prepare a start up script using the following commands:
 
- sudo wget https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/nodered.service -O /lib/systemd/system/nodered.service
+ sudo wget https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/nodered.service -O /etc/systemd/system/nodered.service
 
  sudo wget https://raw.githubusercontent.com/node-red/raspbian-deb-package/master/resources/node-red-start -O /usr/bin/node-red-start
 


### PR DESCRIPTION
/etc/systemd/system belongs to the local system administrator. /lib/systemd/system belongs to the distribution and shouldn't be changed by the user, as changes will collide with possible package updates. Refer to `man 5 systemd.unit`.

Note that I don't own the actual hardware, so I have not tested this change specifically.