### PR TITLE
Enable markdown engine (kramdown)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'coderay', '~> 1.1'
 gem 'middleman-core', '~> 4.1'
 gem 'middleman-cli', '~> 4.1'
 gem 'middleman-asciidoc'
+gem 'kramdown', '~> 1.2'
 
 # This fork just removes platform-specific dependencies from gemspec.
 # See https://github.com/guard/listen/issues/416

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
     hashie (3.4.6)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
+    kramdown (1.9.0)
     memoist (0.15.0)
     middleman-asciidoc (1.0.0.rc.2)
       asciidoctor (>= 1.5.0)
@@ -102,6 +103,7 @@ PLATFORMS
 
 DEPENDENCIES
   coderay (~> 1.1)
+  kramdown (~> 1.2)
   listen!
   middleman-asciidoc
   middleman-cli (~> 4.1)

--- a/config.rb
+++ b/config.rb
@@ -4,6 +4,7 @@ require_relative 'lib/middleman_helpers'
 helpers MiddlemanHelpers
 
 config[:layouts_dir] = '_layouts'
+config[:markdown_engine] = :kramdown
 config[:sass_assets_paths] << Foundation.scss_path
 
 # Custom config variables


### PR DESCRIPTION
Note: Markdown files must have file extension (suffix) .html.md. (If you don’t like it, I can somehow change it.)